### PR TITLE
Add server-soap folder with a basic SOAP service for books

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 	<modules>
 		<module>server</module>
 		<module>client</module>
+		<module>server-soap</module>
 	</modules>
 
 	<properties>

--- a/server-soap/build.gradle
+++ b/server-soap/build.gradle
@@ -1,0 +1,39 @@
+buildscript {
+    ext {
+        springBootVersion = '2.5.4'
+    }
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'eclipse'
+apply plugin: 'org.springframework.boot'
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    springCloudVersion = '2020.0.3'
+}
+
+dependencies {
+    implementation('org.springframework.boot:spring-boot-starter-web-services')
+    implementation('org.springframework.cloud:spring-cloud-starter-netflix-eureka-client')
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}

--- a/server-soap/pom.xml
+++ b/server-soap/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>server-soap</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>server-soap</name>
+    <description>SOAP service for books</description>
+
+    <parent>
+        <groupId>org.test</groupId>
+        <artifactId>feign-eureka</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web-services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/server-soap/src/main/java/demo/BookEndpoint.java
+++ b/server-soap/src/main/java/demo/BookEndpoint.java
@@ -1,0 +1,28 @@
+package demo;
+
+import org.springframework.ws.server.endpoint.annotation.Endpoint;
+import org.springframework.ws.server.endpoint.annotation.PayloadRoot;
+import org.springframework.ws.server.endpoint.annotation.RequestPayload;
+import org.springframework.ws.server.endpoint.annotation.ResponsePayload;
+
+@Endpoint
+public class BookEndpoint {
+
+    private static final String NAMESPACE_URI = "http://example.com/books";
+
+    @PayloadRoot(namespace = NAMESPACE_URI, localPart = "getBookRequest")
+    @ResponsePayload
+    public GetBookResponse getBook(@RequestPayload GetBookRequest request) {
+        GetBookResponse response = new GetBookResponse();
+        response.setBook(findBook(request.getTitle()));
+        return response;
+    }
+
+    private Book findBook(String title) {
+        // Dummy implementation for demonstration purposes
+        Book book = new Book();
+        book.setTitle(title);
+        book.setAuthor("Unknown Author");
+        return book;
+    }
+}

--- a/server-soap/src/main/java/demo/BookServiceApplication.java
+++ b/server-soap/src/main/java/demo/BookServiceApplication.java
@@ -1,0 +1,14 @@
+package demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+@SpringBootApplication
+@EnableDiscoveryClient
+public class BookServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BookServiceApplication.class, args);
+    }
+}

--- a/server-soap/src/main/resources/application.yml
+++ b/server-soap/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: BookService
+
+server:
+  port: 8080
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    leaseRenewalIntervalInSeconds: 10
+    metadataMap:
+      instanceId: ${spring.application.name}:${server.port}


### PR DESCRIPTION
Add a new folder `server-soap` at the root level containing a basic SOAP service for books that is an Eureka client.

* **Add `server-soap` folder and files:**
  - Add `build.gradle` file with dependencies for Spring Boot, Spring Web Services, and Eureka client.
  - Add `pom.xml` file with dependencies for Spring Boot, Spring Web Services, and Eureka client.
  - Add `BookServiceApplication.java` class with `@SpringBootApplication` and `@EnableDiscoveryClient` annotations, and a `main` method to run the application.
  - Add `BookEndpoint.java` class with `@Endpoint` annotation and a method to handle SOAP requests for books.
  - Add `application.yml` file with Eureka client configuration.

* **Modify `pom.xml` file:**
  - Add `server-soap` as a module in the `<modules>` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sobryan/feign-eureka/pull/1?shareId=f6860a99-599e-496f-a8a7-1c1a760cd3e8).